### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This MCP server acts as a bridge between the official [Hacker News API](https://
 
 It enables these tools to fetch and interact with live Hacker News data (posts, comments, users) via standardized MCP endpoints.
 
+<a href="https://glama.ai/mcp/servers/@paabloLC/mcp-hacker-news">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@paabloLC/mcp-hacker-news/badge" alt="Hacker News MCP server" />
+</a>
+
 ## Using with Claude Desktop or Cursor
 
 Add to your Claude desktop config (`claude_desktop_config.json`) or your Cursor config file (`mcp.json`) :


### PR DESCRIPTION
This PR adds a badge for the [MCP Hacker News](https://glama.ai/mcp/servers/@paabloLC/mcp-hacker-news) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@paabloLC/mcp-hacker-news">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@paabloLC/mcp-hacker-news/badge" alt="Hacker News MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.